### PR TITLE
Update for osg-htc

### DIFF
--- a/docs/ac-meeting-archive.md
+++ b/docs/ac-meeting-archive.md
@@ -38,7 +38,7 @@ earlier meeting notes, please contact [Tim Cartwright](mailto:cat@cs.wisc.edu) a
 
 Meetings earlier than 2021-03-10 were the called “OSG Area Coordinators meeting”, although staff were invited.
 
-- 2021-03-03 - Cancelled due to [OSG All-Hands Meeting 2021](https://opensciencegrid.org/all-hands/2021/)
+- 2021-03-03 - Cancelled due to [OSG All-Hands Meeting 2021](https://osg-htc.org/all-hands/2021/)
 - 2021-02-24 - [Operations](https://docs.google.com/presentation/d/1TG5AOK548F3Z_Uh1ue5DnJJeQ_I3mjYgoktwmtGAyY8/) (Jeff Dost)
 - 2021-02-17 - Technology Investigations (Brian Bockelman)
 - 2021-02-10 - [Collaboration Support](https://docs.google.com/presentation/d/1txOVEiFsCXC9lZXlVsknCfiep9vzMsDIVfknxyyoq_o/) (Pascal Paschos)

--- a/docs/area-coordinators.md
+++ b/docs/area-coordinators.md
@@ -9,16 +9,16 @@ The current Area Coordinators are:
 
 | OSG Area | Area Coordinator |
 | :------- | :--------------- |
-| [Collaboration Support](https://opensciencegrid.org/collaboration-support/) | Pascal Paschos, University of Chicago |
+| [Collaboration Support](https://osg-htc.org/collaboration-support/) | Pascal Paschos, University of Chicago |
 | [Global Infrastructure Lab](https://path-cc.io/services/gil/) | Igor Sfiligoi, University of California San Diego |
 | [HTCondor Software Suite](https://htcondor.org) | Todd Tannenbaum, University of Wisconsin&ndash;Madison |
-| [Network Monitoring](https://opensciencegrid.org/networking/) | Shawn McKee, University of Michigan |
-| [Operations](https://opensciencegrid.org/operations/) | Jeff Dost, University of California San Diego |
+| [Network Monitoring](https://osg-htc.org/networking/) | Shawn McKee, University of Michigan |
+| [Operations](https://osg-htc.org/operations/) | Jeff Dost, University of California San Diego |
 | Production Support | Ken Herner, Fermi National Accelerator Lab |
-| [Research Facilitation](https://opensciencegrid.org/research-facilitation) | Lauren Michael, University of Wisconsin&ndash;Madison |
-| [Security](https://opensciencegrid.org/security/) | Josh Drake, Indiana University |
-| [Software and Release](https://opensciencegrid.org/technology/) | Brian Lin and Tim Theisen, University of Wisconsin&ndash;Madison |
-| [Technology Investigations](https://opensciencegrid.org/technology/) | Brian Bockelman, Morgridge Institute for Research |
+| [Research Facilitation](https://osg-htc.org/research-facilitation) | Lauren Michael, University of Wisconsin&ndash;Madison |
+| [Security](https://osg-htc.org/security/) | Josh Drake, Indiana University |
+| [Software and Release](https://osg-htc.org/technology/) | Brian Lin and Tim Theisen, University of Wisconsin&ndash;Madison |
+| [Technology Investigations](https://osg-htc.org/technology/) | Brian Bockelman, Morgridge Institute for Research |
 
 
 ## Meetings

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Consortium.
 The OSG is managed by three key groups, with substantial overlaps in personnel between the groups:
 
 * The **OSG Council** is a group of key stakeholders and the governing body of the OSG Consortium&nbsp;&mdash; for more
-  information, [visit the OSG Council website](https://opensciencegrid.org/council/)
+  information, [visit the OSG Council website](https://osg-htc.org/council/)
 
 * The **OSG Executive Team** manages the program of work and priorities of the OSG Project&nbsp;&mdash;
   [see below](#executive-team)

--- a/docs/staff-meeting.md
+++ b/docs/staff-meeting.md
@@ -93,7 +93,7 @@ Blank lines separate cycles of team presentations.
 - 2022-04-06 - All-Staff Town Hall (Frank Würthwein, AHM feedback and security exercise results)
 - 2022-03-30 - [Security](https://drive.google.com/file/d/1NiyQYD3PPm5QN5430U3i3HawJspVLtyd/) (Josh Drake)
 - 2022-03-23 - [Release](https://docs.google.com/presentation/d/1aDX5NayEpOkVwM5SprhWIhoiP5XG7AeZ6wiXdtzx1Js/) (Tim Theisen)
-- 2022-03-16 - Cancelled due to [OSG All-Hands Meeting 2022](https://opensciencegrid.org/all-hands/2022/)
+- 2022-03-16 - Cancelled due to [OSG All-Hands Meeting 2022](https://osg-htc.org/all-hands/2022/)
 - 2022-03-09 - All-Staff Town Hall
 - 2022-03-02 - [Software](https://docs.google.com/presentation/d/1Zxr66x3p4q3gC4jFAUM5AzH6P4Z5-tqmjzpIooAuTBk) (Brian Lin)
 - 2022-02-23 - Infrastructure Lab ([Igor Sfiligoi](https://docs.google.com/presentation/d/1c4AVSscGoPSHEJvTNMVYhRyT4QamM1Lr/) and [Fabio Andrijauskas](https://docs.google.com/presentation/d/1lw0AnaJb-zjWT2r307DZNmBcL786Vk0l/))


### PR DESCRIPTION
All opensciencegrid.org/** websites have been moved so this is the final clean up of existing pointers to the previous locations.

Another pass will be done in the future to clean up **.opensciencegrid.org subdomains when they are transferred.