### PR TITLE
Update staff-meeting.md

### DIFF
--- a/docs/staff-meeting.md
+++ b/docs/staff-meeting.md
@@ -72,7 +72,6 @@ of a special topic, which will be announced in advance.
 
 ### Upcoming Meetings
 
--   2023-01-25 - HTCSS (Todd Tannenbaum)
 -   2023-02-01 - **All-Staff Town Hall** (Frank Würthwein)
 -   2023-02-08 - Security (Josh Drake)
 -   2023-02-15 - Technology Investigations (Brian Bockelman)
@@ -89,8 +88,7 @@ of a special topic, which will be announced in advance.
 Past meetings are listed newest to oldest.
 Blank lines separate cycles of team presentations.
 
-#### 2022
-
+-   2023-01-25 - [HTCSS](https://docs.google.com/presentation/d/1R3JDYZNKNkMzBhHpj4OejzYXhHvA1nLj/) (Todd Tannenbaum)
 -   2023-01-18 - [Software](https://docs.google.com/presentation/d/1KfaVc7NWJ9WpWT4DVuZNV81wAOpdBKcx0R4AJgMmHXU/) (Brian Lin)
 -   2023-01-11 - Cancelled due to in-person meetings
 -   2023-01-04 - All-Staff Town Hall (our relationship with the NSF CC* program)


### PR DESCRIPTION
Added HTCSS slides from today, plus get rid of the "2022" year heading, as it already contained talks from 2023 and nobody cares to split it up by year...