### PR TITLE
Add July 31, 2024 production meeting

### DIFF
--- a/docs/staff-meeting.md
+++ b/docs/staff-meeting.md
@@ -117,7 +117,7 @@ of a special topic, which will be announced in advance.
 Past meetings are listed newest to oldest.
 Blank lines separate cycles of team presentations.
 
--   2024-07-31 - Production Support (Ken Herner)
+-   2024-07-31 - [Production Support](https://drive.google.com/file/d/1iPM7bVWjfosyizqjT-GuiwyfUCI5ViNi/view) (Ken Herner)
 -   2024-07-24 - Cancelled (PEARC24)
 -   2024-07-17 - **All-Staff Town Hall** (HTC 24 discussion)
 -   2024-07-10 - Cancelled (HTC 24)


### PR DESCRIPTION
I promised to do this for Ken. @osg-cat should we just have ACs  push directly to master with slide updates?